### PR TITLE
for vid2pose parames issue

### DIFF
--- a/scripts/vid2pose.py
+++ b/scripts/vid2pose.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     kps_results = []
     for i, frame_pil in enumerate(tqdm(frames)):
         image_np = cv2.cvtColor(np.array(frame_pil), cv2.COLOR_RGB2BGR)
-        image_np = cv2.resize(image_np, (height, width))
+        image_np = cv2.resize(image_np, (width, height))
         face_result = lmk_extractor(image_np)
         try:
             lmks = face_result['lmks'].astype(np.float32)


### PR DESCRIPTION
I have already test it.

shape it's HEIGHT, WIDTH = img.shape[0:2]. The reason for this, is it's a numpy matrix, where the first value means number of rows, and the second is number of columns.

When you resize it's img = cv2.resize(img, (WIDTH, HEIGHT)).